### PR TITLE
chore: downgrade Next for Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
     "@testing-library/dom": "^10.4.1",
-    "next": "15.3.4",
+    "next": "^14.2.0",
     "next-themes": "^0.2.1",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -27,7 +27,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.3.4",
+    "eslint-config-next": "^14.2.0",
     "lucide-react": "^0.523.0",
     "tailwindcss": "^4",
     "typescript": "^5"


### PR DESCRIPTION
## Summary
- downgrade Next.js to v14 and align React and ESLint config versions for @netlify/plugin-nextjs compatibility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from Google)*
- `npm install` *(fails: 403 Forbidden from npm registry)*
- `npx netlify-cli --version` *(fails: 403 Forbidden from npm registry)*
- `netlify deploy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fcc6d36e083339963a52052430a66