### PR TITLE
fix: mark Deck component as client

### DIFF
--- a/src/Components/Deck/Deck.js
+++ b/src/Components/Deck/Deck.js
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import Card from '../Card/Card';
 import './Deck.css';


### PR DESCRIPTION
## Summary
- add "use client" directive to Deck component
- confirm nested Card and CTAButton components already client-marked

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fcc6e3b388333ae80faba0c0fb244