### PR TITLE
Ensure CTAButton importers are client components

### DIFF
--- a/src/Components/CTAButton/CTAButton.test.js
+++ b/src/Components/CTAButton/CTAButton.test.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { render, screen, fireEvent } from '@testing-library/react';
 import CTAButton from './CTAButton';
 

--- a/src/Components/HeaderCTA.js
+++ b/src/Components/HeaderCTA.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import CTAButton from './CTAButton/CTAButton';
 

--- a/src/app/About/page-old.js
+++ b/src/app/About/page-old.js
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect, useRef } from 'react';
 import CTAButton from '../../Components/CTAButton/CTAButton';
 import Image from 'next/image';


### PR DESCRIPTION
## Summary
- add missing `"use client"` directives to components importing `CTAButton`
- ensure legacy About page and Header CTA run on the client
- mark CTAButton unit tests as client-side

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run test:accessibility` *(fails: development server not running)*

------
https://chatgpt.com/codex/tasks/task_e_689fcc6f0f288333b2b95110ba45ef27