### PR TITLE
Specify Python version for Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,8 @@
   command = "npm run build"
   publish = ".next"
 
+[build.environment]
+  PYTHON_VERSION = "3.11"
+
 [[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary
- declare Python version 3.11 for Netlify builds via `build.environment` section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_689ff32aca588333ac2c660fc0d47e04