### PR TITLE
Use slug-based keys for Deck items

### DIFF
--- a/src/Components/Deck/Deck.js
+++ b/src/Components/Deck/Deck.js
@@ -29,7 +29,7 @@ function Deck({ items, actionType }) {
 
   return (
     <div className="deck-grid">
-      {items.map((item, idx) => {
+      {items.map((item) => {
         let actions = [];
         if (item.links) {
           actionTypes.forEach(type => {
@@ -57,7 +57,7 @@ function Deck({ items, actionType }) {
         }
         return (
           <Card
-            key={idx}
+            key={item.slug}
             {...item}
             actions={actions}
             dataTestId={dataTestId}


### PR DESCRIPTION
## Summary
- Replace index-based React keys with stable `slug` keys in Deck component to avoid key collisions.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b27433608333a584d171cbb7fd0d