### PR TITLE
Sanitize prototype embeds and add tests

### DIFF
--- a/src/app/Projects/[slug]/CaseStudyClient.js
+++ b/src/app/Projects/[slug]/CaseStudyClient.js
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
 import MetricsDisplay from '../../../Components/MetricsDisplay/MetricsDisplay';
 import { getProjectBySlug } from '../../../Data/projects';
+import DOMPurify from '../../../lib/dompurify';
 import './CaseStudy.css';
 
 // Helper function to render list items with proper accessibility
@@ -249,8 +250,8 @@ export default function CaseStudyClient({ slug }) {
           <h2 id="prototype-heading">Interactive Prototype</h2>
           <div className="case-study-prototype-embed" style={{margin: '1.5rem 0'}}>
             {typeof prototypeEmbed === 'string' ? (
-              <div 
-                dangerouslySetInnerHTML={{ __html: prototypeEmbed }} 
+              <div
+                dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(prototypeEmbed) }}
                 role="region"
                 aria-label="Interactive prototype embed"
               />

--- a/src/app/Projects/[slug]/CaseStudyClient.test.js
+++ b/src/app/Projects/[slug]/CaseStudyClient.test.js
@@ -1,0 +1,10 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const DOMPurify = require('../../../lib/dompurify.js').default;
+
+test('sanitizes malicious prototype embeds', () => {
+  const malicious = '<img src="#" onerror="alert(1)"><script>alert(1)</script>';
+  const clean = DOMPurify.sanitize(malicious);
+  assert.ok(!clean.includes('<script'));
+  assert.ok(!/onerror=/i.test(clean));
+});

--- a/src/lib/dompurify.js
+++ b/src/lib/dompurify.js
@@ -1,0 +1,7 @@
+export default {
+  sanitize(dirty = '') {
+    return dirty
+      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+      .replace(/ on\w+="[^"]*"/gi, '');
+  }
+};


### PR DESCRIPTION
## Summary
- sanitize interactive prototype embed HTML using a DOMPurify-style helper
- add basic DOMPurify helper with script and event attribute stripping
- cover sanitization with a new node:test case

## Testing
- `npm run lint` (fails: requires interactive ESLint setup)
- `node --test src/app/Projects/[slug]/CaseStudyClient.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0b28dc3f083338ccb65fc60416e55