### PR TITLE
chore: mark CTA button handlers optional

### DIFF
--- a/src/Components/CTAButton/CTAButton.js
+++ b/src/Components/CTAButton/CTAButton.js
@@ -9,8 +9,8 @@ function CTAButton({
   children,
   variant = 'primary', // 'primary' or 'secondary'
   size = 'medium', // 'small', 'medium', 'large'
-  onClick,
-  href,
+  onClick = undefined,
+  href = undefined,
   disabled = false,
   className = '',
   download = false,


### PR DESCRIPTION
## Summary
- mark `onClick` and `href` parameters optional in `CTAButton`

## Testing
- `npm run build` *(fails: Failed to fetch Inter from Google Fonts)*


------
https://chatgpt.com/codex/tasks/task_e_68a0b59ee99c83338610ef33729a1930