### PR TITLE
docs: add CTAButton props JSDoc

### DIFF
--- a/src/Components/CTAButton/CTAButton.js
+++ b/src/Components/CTAButton/CTAButton.js
@@ -5,6 +5,24 @@ import Link from 'next/link';
 import './CTAButton.css';
 import { Download } from 'lucide-react';
 
+/**
+ * @typedef {React.ButtonHTMLAttributes<HTMLButtonElement> & React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+ *   children: React.ReactNode;
+ *   variant?: 'primary' | 'secondary';
+ *   size?: 'small' | 'medium' | 'large';
+ *   href?: string;
+ *   onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
+ *   download?: boolean;
+ *   showDownloadIcon?: boolean;
+ * }} CTAButtonProps
+ */
+
+/**
+ * Call to action button that can render as a button or link.
+ *
+ * @param {CTAButtonProps} props
+ * @returns {JSX.Element}
+ */
 function CTAButton({
   children,
   variant = 'primary', // 'primary' or 'secondary'


### PR DESCRIPTION
## Summary
- document CTAButton props with JSDoc typedefs for better TypeScript support

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b87949c48333b28631e0ca938e11