### PR TITLE
Remove obsolete system theme helper

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,15 +8,6 @@ import Header from "../Components/Header/Header";
 import Footer from "../Components/Footer/Footer";
 import ClientProvider from "../Components/ClientProvider";
 
-// Client-safe helper that returns the system theme when run in a browser.
-// This function is safe to import/use anywhere because it guards access to window.
-export function getSystemTheme(): 'dark' | 'light' {
-  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  }
-  return 'light';
-}
-
 export const metadata: Metadata = {
   title: "Kainen White | Product & UX Designer",
   description:


### PR DESCRIPTION
## Summary
- remove `getSystemTheme` from layout and drop its export

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68a1046b697c833392224d5de9f139f9