### PR TITLE
feat: integrate dompurify for sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@testing-library/dom": "^10.4.1",
     "next": "^14.2.0",
     "next-themes": "^0.2.1",
+    "dompurify": "^3.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -30,6 +31,7 @@
     "eslint-config-next": "^14.2.0",
     "lucide-react": "^0.523.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/app/Projects/[slug]/CaseStudyClient.js
+++ b/src/app/Projects/[slug]/CaseStudyClient.js
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
 import MetricsDisplay from '../../../Components/MetricsDisplay/MetricsDisplay';
 import { getProjectBySlug } from '../../../Data/projects';
-import DOMPurify from '../../../lib/dompurify';
+import DOMPurify from 'dompurify';
 import './CaseStudy.css';
 
 // Helper function to render list items with proper accessibility

--- a/src/app/Projects/[slug]/CaseStudyClient.test.js
+++ b/src/app/Projects/[slug]/CaseStudyClient.test.js
@@ -1,10 +1,21 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const DOMPurify = require('../../../lib/dompurify.js').default;
+const createDOMPurify = require('dompurify');
+const { JSDOM } = require('jsdom');
+
+const window = new JSDOM('').window;
+const DOMPurify = createDOMPurify(window);
 
 test('sanitizes malicious prototype embeds', () => {
   const malicious = '<img src="#" onerror="alert(1)"><script>alert(1)</script>';
   const clean = DOMPurify.sanitize(malicious);
   assert.ok(!clean.includes('<script'));
   assert.ok(!/onerror=/i.test(clean));
+});
+
+test('sanitizes dangerous image input', () => {
+  const dirty = '<img src=x onerror=alert(1) />';
+  const clean = DOMPurify.sanitize(dirty);
+  assert.ok(!/onerror=/i.test(clean));
+  assert.ok(!/alert\(1\)/i.test(clean));
 });

--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -1,19 +1,19 @@
+import DOMPurify from 'dompurify';
+
 export default function Head() {
+  const themeScript = `
+    (function() {
+      var theme = localStorage.getItem('__theme');
+      if (!theme) {
+        theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      }
+      document.documentElement.setAttribute('data-theme', theme);
+    })();
+  `;
+
   return (
     <>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `
-            (function() {
-              var theme = localStorage.getItem('__theme');
-              if (!theme) {
-                theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-              }
-              document.documentElement.setAttribute('data-theme', theme);
-            })();
-          `,
-        }}
-      />
+      <script dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(themeScript) }} />
     </>
   );
 }

--- a/src/lib/dompurify.js
+++ b/src/lib/dompurify.js
@@ -1,7 +1,3 @@
-export default {
-  sanitize(dirty = '') {
-    return dirty
-      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-      .replace(/ on\w+="[^"]*"/gi, '');
-  }
-};
+import DOMPurify from 'dompurify';
+
+export default DOMPurify;


### PR DESCRIPTION
## Summary
- use the DOMPurify library for sanitizing HTML
- sanitize theme script in head component
- test DOMPurify against dangerous HTML inputs

## Testing
- `node --test` *(fails: Cannot find module 'dompurify'; SyntaxError: Unexpected token '<')*
- `npm install --package-lock-only` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dompurify)*

------
https://chatgpt.com/codex/tasks/task_e_68a1043b5c04833394ec11ee85eb1491