### PR TITLE
refactor: use shared Fisher-Yates shuffle

### DIFF
--- a/src/Data/clients.ts
+++ b/src/Data/clients.ts
@@ -1,3 +1,5 @@
+import { shuffle } from '../lib/shuffle'
+
 export interface Client {
   id: string
   name: string
@@ -115,6 +117,5 @@ export const getClientByTestimonialId = (testimonialId: string): Client | undefi
 
 // Helper function to get random clients
 export const getRandomClients = (count: number): Client[] => {
-  const shuffled = [...clients].sort(() => 0.5 - Math.random())
-  return shuffled.slice(0, count)
+  return shuffle(clients).slice(0, count)
 }

--- a/src/Data/testimonials.ts
+++ b/src/Data/testimonials.ts
@@ -1,3 +1,5 @@
+import { shuffle } from '../lib/shuffle'
+
 export interface Testimonial {
   id: string
   name: string
@@ -78,6 +80,5 @@ export const getTestimonialsByProject = (projectSlug: string): Testimonial[] => 
 
 // Helper function to get random testimonials
 export const getRandomTestimonials = (count: number): Testimonial[] => {
-  const shuffled = [...testimonials].sort(() => 0.5 - Math.random())
-  return shuffled.slice(0, count)
+  return shuffle(testimonials).slice(0, count)
 }

--- a/src/_tests_/shuffle.test.ts
+++ b/src/_tests_/shuffle.test.ts
@@ -1,0 +1,29 @@
+import { shuffle } from '../lib/shuffle'
+
+function createRNG(seed: number): () => number {
+  return () => {
+    const x = Math.sin(seed++) * 10000
+    return x - Math.floor(x)
+  }
+}
+
+describe('shuffle', () => {
+  it('produces roughly uniform permutations', () => {
+    const rng = createRNG(42)
+    const arr = [1, 2, 3]
+    const iterations = 60000
+    const counts: Record<string, number> = {}
+
+    for (let i = 0; i < iterations; i++) {
+      const result = shuffle(arr, rng).join(',')
+      counts[result] = (counts[result] || 0) + 1
+    }
+
+    const expected = iterations / 6
+    const tolerance = expected * 0.05
+    Object.values(counts).forEach(count => {
+      expect(count).toBeGreaterThanOrEqual(expected - tolerance)
+      expect(count).toBeLessThanOrEqual(expected + tolerance)
+    })
+  })
+})

--- a/src/lib/shuffle.ts
+++ b/src/lib/shuffle.ts
@@ -1,0 +1,8 @@
+export function shuffle<T>(array: T[], rng: () => number = Math.random): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- replace array.sort randomization with shared Fisher–Yates shuffle
- add shuffle utility for reuse in data modules
- test shuffle for roughly uniform permutations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest src/_tests_/shuffle.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm run lint` *(interactive prompt prevents completion)*

------
https://chatgpt.com/codex/tasks/task_e_68a1043715c883338cbb05a9f5140fbf