### PR TITLE
Use centralized logger for contact form submissions

### DIFF
--- a/src/app/Contact/ContactClient.js
+++ b/src/app/Contact/ContactClient.js
@@ -5,6 +5,7 @@ import React, { useState } from "react";
 import { Mail, CheckCircle, AlertCircle, Phone, MapPin } from 'lucide-react';
 import emailjs from '@emailjs/browser';
 import CTAButton from '../../Components/CTAButton/CTAButton';
+import logger from '../../lib/logger';
 
 function Contact() {
   const [formStatus, setFormStatus] = useState(''); // '', 'success', 'error', 'submitting'
@@ -42,7 +43,7 @@ function Contact() {
     
     // Check if EmailJS is properly configured
     if (!EMAILJS_SERVICE_ID || !EMAILJS_TEMPLATE_ID || !EMAILJS_PUBLIC_KEY) {
-      console.error('EmailJS is not properly configured. Missing credentials.');
+      logger.error('EmailJS is not properly configured. Missing credentials.');
       setFormStatus('error');
       return;
     }
@@ -61,7 +62,7 @@ function Contact() {
         },
         EMAILJS_PUBLIC_KEY
       );
-      console.log('EmailJS Success:', result);
+      logger.log('EmailJS Success:', result);
       setFormStatus('success');
       setFormData({ name: '', email: '', message: '' });
       // Google Analytics conversion tracking for successful submission
@@ -74,7 +75,7 @@ function Contact() {
         });
       }
     } catch (err) {
-      console.error('EmailJS Error:', err);
+      logger.error('EmailJS Error:', err);
       setFormStatus('error');
       // Google Analytics event for failed submission
       if (window.gtag) {

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,0 +1,17 @@
+const isProduction = process.env.NODE_ENV === 'production';
+
+const logger = {
+  log: (...args) => {
+    if (!isProduction) {
+      console.log(...args);
+    }
+  },
+  error: (...args) => {
+    if (!isProduction) {
+      console.error(...args);
+    }
+  },
+};
+
+export default logger;
+


### PR DESCRIPTION
## Summary
- Replace direct console logging in contact form with environment-aware logger
- Add simple logger utility that suppresses logs in production

## Testing
- `npm test` (fails: Missing script)
- `npx eslint src/app/Contact/ContactClient.js src/lib/logger.js && echo "Lint passed"`


------
https://chatgpt.com/codex/tasks/task_e_68a1045df0b08333a19416f806867b70