### PR TITLE
fix: correct Mozilla heading hierarchy

### DIFF
--- a/src/Pages/Blog/Blog.js
+++ b/src/Pages/Blog/Blog.js
@@ -11,7 +11,7 @@ function Blog() {
         <p>Share insights from online courses, workshops, or personal projects…</p>
       </div>
       <div>
-        <h2>Let&apos;s support Mozilla</h2>
+        <h3>Let&apos;s support Mozilla</h3>
         <p>I love Mozilla and you should too.</p>
         <p>
           It&apos;s a low bar, but Mozilla is the best of the four major client-side internet companies: Apple, Google,


### PR DESCRIPTION
## Summary
- refine highlighted posts to use proper heading levels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/Pages/Blog/Blog.js`
- `npm run test:accessibility` *(fails: Development server not running on port 3001)*

------
https://chatgpt.com/codex/tasks/task_e_68a10469bc98833398763c04d691a293