### PR TITLE
Remove redundant margin rule from metrics paragraph

### DIFF
--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -125,7 +125,6 @@ export default function HomePageClient() {
         <h2 style={{ marginBottom: "1rem" }}>Results That Matter</h2>
         <p
           style={{
-            marginBottom: "3rem",
             maxWidth: "600px",
             margin: "0 auto 3rem",
             color: "#fff",


### PR DESCRIPTION
## Summary
- streamline portfolio metrics section paragraph spacing by removing duplicate `marginBottom`

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a1047257508333812a7b87df69ad04